### PR TITLE
Update nginx configs to work with Workbench Notebooks health check

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -34,10 +34,14 @@ RUN Rscript \
 COPY startup.sh /root/startup.sh
 COPY bootstrap.R /root/bootstrap.R
 
+
 # Configure nginx as a proxy
 COPY cache_cookies.lua /usr/local/openresty/nginx/
 COPY add_cookies.lua /usr/local/openresty/nginx/
 COPY nginx.conf /etc/nginx/nginx.conf
+
+# Add rwx permissions to nginx configs
+RUN chmod -R 777 /usr/local/openresty
 
 WORKDIR /root
 ENTRYPOINT ["/bin/bash", "/root/startup.sh"]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -34,7 +34,6 @@ RUN Rscript \
 COPY startup.sh /root/startup.sh
 COPY bootstrap.R /root/bootstrap.R
 
-
 # Configure nginx as a proxy
 COPY cache_cookies.lua /usr/local/openresty/nginx/
 COPY add_cookies.lua /usr/local/openresty/nginx/

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -39,6 +39,9 @@ COPY cache_cookies.lua /usr/local/openresty/nginx/
 COPY add_cookies.lua /usr/local/openresty/nginx/
 COPY nginx.conf /etc/nginx/nginx.conf
 
+# Add rwx permissions to nginx configs
+RUN chmod -R 777 /usr/local/openresty
+
 WORKDIR /root
 ENTRYPOINT ["/bin/bash", "/root/startup.sh"]
 CMD ["/bin/bash", "/root/startup.sh"]

--- a/Docker/nginx.conf
+++ b/Docker/nginx.conf
@@ -16,6 +16,10 @@ http {
 
   server {
     listen 8080;
+
+    location /api {
+        return 200;
+    }
     
     location /api/ {
         return 200;

--- a/Docker/nginx.conf
+++ b/Docker/nginx.conf
@@ -25,7 +25,6 @@ http {
         return 200;
     }
 
-
     location / {
       proxy_pass http://127.0.0.1:8787;
       proxy_redirect http://localhost:8787/ $scheme://$http_host/;

--- a/Docker/nginx.conf
+++ b/Docker/nginx.conf
@@ -16,10 +16,15 @@ http {
 
   server {
     listen 8080;
+
+    location /api {
+        return 200;
+    }
     
     location /api/ {
         return 200;
     }
+
 
     location / {
       proxy_pass http://127.0.0.1:8787;


### PR DESCRIPTION
https://www.digitalocean.com/community/tutorials/nginx-location-directive

The location directive to override the /api/ health check doesn't account for "http:/localhost:8080/api" given that the " NGINX location block for a directory" only checks from the appended "/" and beyond. 

The following location block will match any request starting with /images/ but continue with searching for more specific block for the requested URI.

This pull requests seeks to address this along with ensuring the lua configs allow for nginx to have read and write access. 

Example: 
```
test@test-r-container-3 ~ $ curl -I localhost:8080/api/
HTTP/1.1 200 OK
Server: openresty/1.25.3.2
Date: Fri, 09 Aug 2024 23:44:48 GMT
Content-Type: text/plain
Content-Length: 0
Connection: keep-alive

test@test-r-container-3 ~ $ curl -I localhost:8080/api 
HTTP/1.1 404 Not Found
Server: openresty/1.25.3.2
Date: Fri, 09 Aug 2024 23:44:51 GMT
Content-Type: text/html
Content-Length: 2352
Connection: keep-alive
X-Content-Type-Options: nosniff
```
